### PR TITLE
All Numeric Values Convert to `float`

### DIFF
--- a/src/Laravel/Revisionable.php
+++ b/src/Laravel/Revisionable.php
@@ -112,6 +112,10 @@ trait Revisionable
                 return $this->value;
             }
 
+            if (is_numeric($attribute)){
+                return floatval($attribute);
+            }
+
             if (is_string($attribute) && $this->isJson($attribute)) {
                 return json_decode($attribute, true);
             }


### PR DESCRIPTION
Model üzerindeki verilerin tipini bilmiyoruz. `integer` ya da `float` olabilir. 
Bu yüzden hepsini `float` olarak ele alıyoruz. `align` olanlar eleniyor, geriye değişmiş olanlar kalıyor. 